### PR TITLE
[ANNA HAMANN] StarWars Planets Search

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <div />
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Header() {
+  return (
+    <div />
+  );
+}

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Loading() {
+  return (
+    <div />
+  );
+}

--- a/src/components/PlanetsTable.jsx
+++ b/src/components/PlanetsTable.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function PlanetsTable() {
+  return (
+    <div />
+  );
+}

--- a/src/contextAPI/PlanetsContext.js
+++ b/src/contextAPI/PlanetsContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default PlanetsContext = createContext();

--- a/src/contextAPI/PlanetsProvider.js
+++ b/src/contextAPI/PlanetsProvider.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function PlanetsProvider() {
+  return (
+    <div />
+  );
+}

--- a/src/contextAPI/requestAPI.js
+++ b/src/contextAPI/requestAPI.js
@@ -1,0 +1,5 @@
+export default async function requestAPI() {
+  const response = await fetch('https://swapi-trybe.herokuapp.com/api/planets/');
+  const planets = (response.results).json();
+  return planets;
+}


### PR DESCRIPTION
Requisitos obrigatórios:
- [ ]  1 - Faça uma requisição para o endpoint /planets da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna residents
- [ ]  2 - Filtre a tabela através de um texto, inserido num campo de texto, exibindo somente os planetas cujos nomes incluam o texto digitado
- [ ]  3 - Crie um filtro para valores numéricos
- [ ]  4 - Não utilize filtros repetidos
- [ ]  5 - Apague o filtro de valores numéricos e desfaça as filtragens dos dados da tabela ao clicar no ícone de X de um dos filtros

Requisito bônus:
- [ ]  6 - Ordene as colunas de forma ascendente ou descendente